### PR TITLE
Feature: @LoginUser 어노테이션으로 인증 정보 AOP로 받아오는 기능 개발

### DIFF
--- a/src/main/java/com/fthon/save_track/auth/config/WebConfig.java
+++ b/src/main/java/com/fthon/save_track/auth/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.fthon.save_track.auth.config;
+
+
+import com.fthon.save_track.auth.resolvers.LoginedUserArgumentResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@AllArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginedUserArgumentResolver loginedUserArgumentResolver;
+
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginedUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/fthon/save_track/auth/resolvers/LoginedUserArgumentResolver.java
+++ b/src/main/java/com/fthon/save_track/auth/resolvers/LoginedUserArgumentResolver.java
@@ -12,7 +12,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-public class LoginedUserArgumentResolvers implements HandlerMethodArgumentResolver {
+public class LoginedUserArgumentResolver implements HandlerMethodArgumentResolver {
 
 
     @Override

--- a/src/main/java/com/fthon/save_track/auth/resolvers/LoginedUserArgumentResolvers.java
+++ b/src/main/java/com/fthon/save_track/auth/resolvers/LoginedUserArgumentResolvers.java
@@ -1,0 +1,41 @@
+package com.fthon.save_track.auth.resolvers;
+
+
+import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
+import com.fthon.save_track.auth.resolvers.annotation.LoginedUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginedUserArgumentResolvers implements HandlerMethodArgumentResolver {
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isParameterTypeSupported = parameter.getParameterType().isAssignableFrom(AuthenticatedUserDto.class);
+        boolean hasAnnotation = parameter.hasParameterAnnotation(LoginedUser.class);
+
+        return isParameterTypeSupported && hasAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if(principal instanceof AuthenticatedUserDto dto){
+            return dto;
+        }
+
+        // 개발 단계에서 임시로 사용할 객체
+        return new AuthenticatedUserDto(
+                "user-001",
+                "useremail@email.com",
+                "test"
+        );
+    }
+}

--- a/src/main/java/com/fthon/save_track/auth/resolvers/annotation/LoginedUser.java
+++ b/src/main/java/com/fthon/save_track/auth/resolvers/annotation/LoginedUser.java
@@ -1,6 +1,8 @@
 package com.fthon.save_track.auth.resolvers.annotation;
 
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,5 +10,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
 public @interface LoginedUser {
 }

--- a/src/main/java/com/fthon/save_track/auth/resolvers/annotation/LoginedUser.java
+++ b/src/main/java/com/fthon/save_track/auth/resolvers/annotation/LoginedUser.java
@@ -1,0 +1,12 @@
+package com.fthon.save_track.auth.resolvers.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginedUser {
+}

--- a/src/main/java/com/fthon/save_track/badge/controller/BadgeController.java
+++ b/src/main/java/com/fthon/save_track/badge/controller/BadgeController.java
@@ -1,6 +1,8 @@
 package com.fthon.save_track.badge.controller;
 
 
+import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
+import com.fthon.save_track.auth.resolvers.annotation.LoginedUser;
 import com.fthon.save_track.badge.dto.BadgeSearchResponse;
 import com.fthon.save_track.common.dto.CommonResponse;
 import com.fthon.save_track.common.dto.ErrorResponse;
@@ -27,7 +29,9 @@ public class BadgeController {
     @ApiResponse(responseCode = "400", description = "잘못된 요청",
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     @GetMapping("")
-    public ResponseEntity<BadgeListResponse> getList() {
+    public ResponseEntity<BadgeListResponse> getList(
+            @LoginedUser AuthenticatedUserDto userInfo
+    ) {
         return ResponseEntity.ok(null);
     }
 

--- a/src/main/java/com/fthon/save_track/event/controller/EventController.java
+++ b/src/main/java/com/fthon/save_track/event/controller/EventController.java
@@ -1,9 +1,12 @@
 package com.fthon.save_track.event.controller;
 
 
+import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
+import com.fthon.save_track.auth.resolvers.annotation.LoginedUser;
 import com.fthon.save_track.common.dto.CommonResponse;
 import com.fthon.save_track.common.dto.ErrorResponse;
 import com.fthon.save_track.event.dto.request.EventCreateRequest;
+import com.fthon.save_track.event.dto.request.EventUpdateRequest;
 import com.fthon.save_track.event.dto.response.EventDetailSearchResponse;
 import com.fthon.save_track.event.dto.response.EventSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -58,7 +61,8 @@ public class EventController {
     @PostMapping("/{eventId}")
     public ResponseEntity<Void> addEvent(
             @Parameter(description = "생성할 이벤트의 ID") @PathVariable String eventId,
-            @RequestBody EventCreateRequest reqBody
+            @RequestBody EventCreateRequest reqBody,
+            @LoginedUser AuthenticatedUserDto userInfo
     ){
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -71,7 +75,9 @@ public class EventController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     @PutMapping("/{eventId}")
     public ResponseEntity<Void> updateEvent(
-            @Parameter(description = "수정할 이벤트의 ID") @PathVariable String eventId
+            @Parameter(description = "수정할 이벤트의 ID") @PathVariable String eventId,
+            @RequestBody EventUpdateRequest updateInfo,
+            @LoginedUser AuthenticatedUserDto userInfo
     ){
         return ResponseEntity.ok().build();
     }
@@ -84,7 +90,8 @@ public class EventController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     @PostMapping("/{eventId}/subscribe")
     public ResponseEntity<Void> subscribe(
-            @Parameter(description = "구독할 이벤트의 ID") @PathVariable String eventId
+            @Parameter(description = "구독할 이벤트의 ID") @PathVariable String eventId,
+            @LoginedUser AuthenticatedUserDto userInfo
     ){
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -95,7 +102,8 @@ public class EventController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     @DeleteMapping("/{eventId}/subscribe")
     public ResponseEntity<Void> cancelSubscribe(
-            @Parameter(description = "구독 취소할 이벤트의 ID") @PathVariable String eventId
+            @Parameter(description = "구독 취소할 이벤트의 ID") @PathVariable String eventId,
+            @LoginedUser AuthenticatedUserDto userInfo
     ){
         return ResponseEntity.ok().build();
     }
@@ -109,7 +117,8 @@ public class EventController {
             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     @PostMapping("/{eventId}/check")
     public ResponseEntity<Void> checkEvent(
-            @Parameter(description = "완료할 이벤트의 ID") @PathVariable String eventId
+            @Parameter(description = "완료할 이벤트의 ID") @PathVariable String eventId,
+            @LoginedUser AuthenticatedUserDto userInfo
     ){
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/fthon/save_track/report/controller/ReportController.java
+++ b/src/main/java/com/fthon/save_track/report/controller/ReportController.java
@@ -1,6 +1,8 @@
 package com.fthon.save_track.report.controller;
 
 
+import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
+import com.fthon.save_track.auth.resolvers.annotation.LoginedUser;
 import com.fthon.save_track.common.dto.CommonResponse;
 import com.fthon.save_track.common.dto.ErrorResponse;
 import com.fthon.save_track.report.dto.ReportDateResponse;
@@ -35,7 +37,8 @@ public class ReportController {
             @Parameter(description = "조회 시작 날짜 (yyyy-MM-dd 형식)")
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
             @Parameter(description = "조회 종료 날짜 (yyyy-MM-dd 형식)")
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+            @LoginedUser AuthenticatedUserDto userInfo
     ) {
         return ResponseEntity.ok(null);
     }


### PR DESCRIPTION
### 개요
- ArgumentResolver를 활용하여 로그인된 유저의 정보를 받아오는 기능을 개발하였습니다.

### 상세
- 사용법 예시는 아래와 같습니다.
```java
    public ResponseEntity<Void> controllerMethod1(
            @LoginedUser AuthenticatedUserDto userInfo
    ){
        return ResponseEntity.ok().build();
    }

```
- 현재 개발 중에서는 일일히 로그인하게 하면 불편하기 때문에 일단 무조건 로그인 처리가 가능하도록 처리하였습니다.
```java
    @Override
    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();

        if(principal instanceof AuthenticatedUserDto dto){
            return dto;
        }

        // 개발 단계에서 임시로 사용할 객체
        return new AuthenticatedUserDto(
                "user-001",
                "useremail@email.com",
                "test"
        );
    }
```
