### PR TITLE
Feature: 뱃지 리스트 조회 

### DIFF
--- a/src/main/java/com/fthon/save_track/auth/dto/AuthenticatedUserDto.java
+++ b/src/main/java/com/fthon/save_track/auth/dto/AuthenticatedUserDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AuthenticatedUserDto {
 
-    private final String uid;
+    private final Long id;
     private final String email;
     private final String nickname;
 }

--- a/src/main/java/com/fthon/save_track/auth/resolvers/LoginedUserArgumentResolver.java
+++ b/src/main/java/com/fthon/save_track/auth/resolvers/LoginedUserArgumentResolver.java
@@ -33,7 +33,7 @@ public class LoginedUserArgumentResolver implements HandlerMethodArgumentResolve
 
         // 개발 단계에서 임시로 사용할 객체
         return new AuthenticatedUserDto(
-                "user-001",
+                1L,
                 "useremail@email.com",
                 "test"
         );

--- a/src/main/java/com/fthon/save_track/auth/service/AuthService.java
+++ b/src/main/java/com/fthon/save_track/auth/service/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
 
         return jwtUtils.sign(
                 new AuthenticatedUserDto(
-                        user.getId().toString(),
+                        user.getId(),
                         user.getEmail(),
                         user.getNickname()
                 ),

--- a/src/main/java/com/fthon/save_track/auth/utils/JwtUtils.java
+++ b/src/main/java/com/fthon/save_track/auth/utils/JwtUtils.java
@@ -34,7 +34,7 @@ public class JwtUtils {
         Date expiryDate = new Date(issueTime.getTime() + expireTime);
 
         return Jwts.builder()
-                .subject(userInfo.getUid())
+                .subject(String.valueOf(userInfo.getId()))
                 .claim(EMAIL_CLAIM_NAME, userInfo.getEmail())
                 .claim(NICKNAME_CLAIM_NAME, userInfo.getNickname())
                 .issuedAt(issueTime)
@@ -69,7 +69,7 @@ public class JwtUtils {
 
 
         return new AuthenticatedUserDto(
-                payload.getSubject(),
+                Long.parseLong(payload.getSubject()),
                 payload.get(EMAIL_CLAIM_NAME, String.class),
                 payload.get(NICKNAME_CLAIM_NAME, String.class)
         );

--- a/src/main/java/com/fthon/save_track/badge/controller/BadgeController.java
+++ b/src/main/java/com/fthon/save_track/badge/controller/BadgeController.java
@@ -4,6 +4,7 @@ package com.fthon.save_track.badge.controller;
 import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
 import com.fthon.save_track.auth.resolvers.annotation.LoginedUser;
 import com.fthon.save_track.badge.dto.BadgeSearchResponse;
+import com.fthon.save_track.badge.integration.BadgeService;
 import com.fthon.save_track.common.dto.CommonResponse;
 import com.fthon.save_track.common.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,8 +22,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/badges")
+@RequiredArgsConstructor
 @Tag(name = "뱃지 관련 API", description = "뱃지 관련 API")
 public class BadgeController {
+
+    private final BadgeService badgeService;
 
     @Operation(summary = "뱃지 목록 조회", description = "모든 뱃지의 목록을 조회합니다")
     @ApiResponse(responseCode = "200", description = "성공적으로 조회됨",
@@ -32,9 +37,13 @@ public class BadgeController {
     public ResponseEntity<BadgeListResponse> getList(
             @LoginedUser AuthenticatedUserDto userInfo
     ) {
-        return ResponseEntity.ok(null);
+        BadgeListResponse respBody = new BadgeListResponse(badgeService.getBadges(userInfo.getId()));
+        return ResponseEntity.ok(respBody);
     }
 
+
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
     public static class BadgeListResponse extends CommonResponse<List<BadgeSearchResponse>> {
         public BadgeListResponse(List<BadgeSearchResponse> data) {
             super(data);

--- a/src/main/java/com/fthon/save_track/badge/dto/BadgeSearchResponse.java
+++ b/src/main/java/com/fthon/save_track/badge/dto/BadgeSearchResponse.java
@@ -11,7 +11,8 @@ import java.time.ZonedDateTime;
 @Getter
 public class BadgeSearchResponse {
 
-    private String badgeId;
+    private Long badgeId;
     private String badgeName;
+    private boolean acquired;
     private ZonedDateTime acquiredAt;
 }

--- a/src/main/java/com/fthon/save_track/badge/integration/BadgeService.java
+++ b/src/main/java/com/fthon/save_track/badge/integration/BadgeService.java
@@ -1,11 +1,11 @@
-package com.fthon.save_track.badge.service;
+package com.fthon.save_track.badge.integration;
 
 
 import com.fthon.save_track.badge.dto.AcquiredBadgeDto;
+import com.fthon.save_track.badge.dto.BadgeSearchResponse;
 import com.fthon.save_track.badge.persistence.Badge;
 import com.fthon.save_track.badge.repository.BadgeRepository;
 import com.fthon.save_track.user.persistence.User;
-import com.fthon.save_track.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +19,7 @@ import java.util.List;
 public class BadgeService {
 
     private final BadgeRepository badgeRepository;
+
 
     /**
      * 특정 이벤트를 완료한 후 실행하는 메서드로, 사용자가 뱃지를 얻을 수 있는지 확인하고 얻은 뱃지를 DB에 저장 후 해당 뱃지 정보를 반환합니다
@@ -40,4 +41,13 @@ public class BadgeService {
     }
 
 
+    /**
+     * 뱃지의 전체 리스트를 조회. 사용자가 얻었는지의 정보가 포함되어 있음.
+     * @author minseok kim
+     * @param
+     * @throws
+    */
+    public List<BadgeSearchResponse> getBadges(Long userId) {
+        return badgeRepository.findAllBadgesByUserId(userId);
+    }
 }

--- a/src/main/java/com/fthon/save_track/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/fthon/save_track/badge/repository/BadgeRepository.java
@@ -1,5 +1,6 @@
 package com.fthon.save_track.badge.repository;
 
+import com.fthon.save_track.badge.dto.BadgeSearchResponse;
 import com.fthon.save_track.badge.persistence.Badge;
 import com.fthon.save_track.user.persistence.User;
 import org.springframework.data.jpa.repository.Query;
@@ -18,4 +19,10 @@ public interface BadgeRepository extends CrudRepository<Badge, Long> {
             "WHERE b.id not in (SELECT ub.badge.id FROM UserBadge ub WHERE ub.user = :user)")
     List<Badge> findBadgesNotAcquired(@Param("user") User user);
 
+
+    @Query("SELECT NEW com.fthon.save_track.badge.dto.BadgeSearchResponse(" +
+            "b.id, b.name,  CASE WHEN ub.id IS NOT NULL THEN true ELSE false END , ub.createdAt" +
+            ") FROM Badge b " +
+            "LEFT JOIN UserBadge ub ON b = ub.badge  AND ub.user.id = :userId")
+    List<BadgeSearchResponse> findAllBadgesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/fthon/save_track/common/dto/CommonResponse.java
+++ b/src/main/java/com/fthon/save_track/common/dto/CommonResponse.java
@@ -1,11 +1,14 @@
 package com.fthon.save_track.common.dto;
 
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 public class CommonResponse<T> {
-    private final T data;
+    private T data;
 }

--- a/src/test/java/com/fthon/save_track/auth/utils/JwtUtilsTest.java
+++ b/src/test/java/com/fthon/save_track/auth/utils/JwtUtilsTest.java
@@ -23,13 +23,13 @@ class JwtUtilsTest {
     @DisplayName("JWT 토큰을 생성하고 Parsing 할 수 있다.")
     void testCreateAndParse() throws Exception{
         // given
-        AuthenticatedUserDto givenUser = new AuthenticatedUserDto("userUid", "email", "nickname");
+        AuthenticatedUserDto givenUser = new AuthenticatedUserDto(1L, "email", "nickname");
         // when
         String jwt = jwtUtils.sign(givenUser, new Date());
         // then
         AuthenticatedUserDto parsedUser = jwtUtils.getUser(jwt);
 
-        assertThat(parsedUser.getUid()).isEqualTo(givenUser.getUid());
+        assertThat(parsedUser.getId()).isEqualTo(givenUser.getId());
         assertThat(parsedUser.getEmail()).isEqualTo(givenUser.getEmail());
         assertThat(parsedUser.getNickname()).isEqualTo(givenUser.getNickname());
     }
@@ -53,7 +53,7 @@ class JwtUtilsTest {
 
     private static Stream<Arguments> createJwtVerifyInput(){
         JwtUtils jwtUtils = new JwtUtils(secretKey, 1000000L);
-        AuthenticatedUserDto userInfo = new AuthenticatedUserDto("userUid", "email", "nickname");
+        AuthenticatedUserDto userInfo = new AuthenticatedUserDto(1L, "email", "nickname");
 
         String goodJwt = jwtUtils.sign(userInfo, new Date());
         String expiredJwt = jwtUtils.sign(userInfo, new Date(0));

--- a/src/test/java/com/fthon/save_track/badge/integration/BadgeIntegrationTest.java
+++ b/src/test/java/com/fthon/save_track/badge/integration/BadgeIntegrationTest.java
@@ -1,5 +1,9 @@
-package com.fthon.save_track.badge.service;
+package com.fthon.save_track.badge.integration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
+import com.fthon.save_track.auth.utils.JwtUtils;
+import com.fthon.save_track.badge.controller.BadgeController;
 import com.fthon.save_track.badge.dto.AcquiredBadgeDto;
 import com.fthon.save_track.badge.persistence.Badge;
 import com.fthon.save_track.badge.persistence.IndividualCategoryCountStrategy;
@@ -12,22 +16,42 @@ import com.fthon.save_track.event.persistence.EventRepository;
 import com.fthon.save_track.user.persistence.User;
 import com.fthon.save_track.user.persistence.UserBadge;
 import com.fthon.save_track.user.repository.UserRepository;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 
 
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-class BadgeServiceTest {
+@AutoConfigureMockMvc
+class BadgeIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Autowired
     private CategoryRepository categoryRepository;
@@ -78,5 +102,42 @@ class BadgeServiceTest {
         assertThat(user.getBadges().stream().map(UserBadge::getBadge)).containsAll(List.of(badge1, badge3));
     }
 
+    @Test
+    @DisplayName("뱃지 전체 리스트를 조회할 수 있다.")
+    void testSearchBadges() throws Exception{
+        // given
+        User user = new User("유저", 123L, "email@email.com");
+        Category category = new Category("카테고리 1");
+
+        Event event = new Event(category, List.of(), "이벤트", "내용", "메시지1", "메시지2", "메시지3");
+
+        Badge badge1 = new Badge("카테고리 1 절약왕", new IndividualCategoryCountStrategy(2, category));
+        Badge badge2 = new Badge("전체 3개이상 절약왕", new TotalCategoryCountStrategy(3));
+
+        user.addBadge(badge1);
+
+        categoryRepository.save(category);
+        eventRepository.save(event);
+        badgeRepository.saveAll(List.of(badge1, badge2));
+        userRepository.save(user);
+        // when
+        String jwt = jwtUtils.sign(new AuthenticatedUserDto(user.getId(), user.getEmail(), user.getNickname()), new Date());
+        String uri = "/api/badges";
+
+        MvcResult mvcResult = mockMvc.perform(get(uri).header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt))
+                .andDo(print())
+                .andReturn();
+
+
+        // then
+        BadgeController.BadgeListResponse result = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), BadgeController.BadgeListResponse.class);
+
+        assertThat(result.getData()).extracting("badgeId", "badgeName", "acquired")
+                .containsAll(
+                        List.of(
+                            Tuple.tuple(badge1.getId(), badge1.getName(), true),
+                            Tuple.tuple(badge2.getId(), badge2.getName(), false)
+                        ));
+    }
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -21,3 +21,9 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true


### PR DESCRIPTION
### 개요
- 뱃지 리스트를 조회하는 API를 개발하였습니다.

### 상세
- 요청 예시 API는 다음과 같습니다.
```
GET /api/badges
```
- 응답 예시는 다음과 같습니다.
```
HTTP/1.1 200 OK

{
    "data": [
        {
            "badgeId": 621533005354893487,
            "badgeName": "카테고리 1 절약왕",
            "acquired": true,
            "acquiredAt": "2024-09-11T11:30:16.009317+09:00"
        },
        {
            "badgeId": 621533005371672360,
            "badgeName": "전체 3개이상 절약왕",
            "acquired": false,
            "acquiredAt": null
        }
    ]
}
```

### 기타
- 추가 작업하면서 JWT 인증 관련해서 String을 Long으로 바꾸는 작업이 있었습니다! 이는 무시하셔도 되고 뱃지 도메인 위주만 봐주시면 됩니다!