### PR TITLE
Feature: 기간별 리포트 조회 API 개발

### DIFF
--- a/src/main/java/com/fthon/save_track/auth/controller/AuthController.java
+++ b/src/main/java/com/fthon/save_track/auth/controller/AuthController.java
@@ -3,7 +3,7 @@ package com.fthon.save_track.auth.controller;
 
 import com.fthon.save_track.auth.dto.OAuth2LoginRequest;
 import com.fthon.save_track.auth.dto.LoginResponse;
-import com.fthon.save_track.auth.service.AuthService;
+import com.fthon.save_track.user.service.UserService;
 import com.fthon.save_track.common.dto.CommonResponse;
 import com.fthon.save_track.common.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "인증 관련 API", description = "OAuth2 로그인 관련 API")
 public class AuthController {
 
-    private final AuthService authService;
+    private final UserService userService;
 
     @Operation(summary = "OAuth2 로그인", description = "OAuth2 로그인을 처리합니다.")
     @ApiResponse(responseCode = "200", description = "성공적으로 로그인된 경우로, Access Token은 Response Body에 담겨서 전달됩니다.")
@@ -31,7 +31,7 @@ public class AuthController {
             @RequestBody OAuth2LoginRequest reqBody
 
     ){
-        String jwt = authService.doOAuth2Login(reqBody);
+        String jwt = userService.doOAuth2Login(reqBody);
 
         return new LoginResp(200, new LoginResponse(jwt));
     }
@@ -41,7 +41,7 @@ public class AuthController {
     public LoginResp tempLogin(
             @RequestParam String email
     ){
-        String jwt = authService.loginByEmail(email);
+        String jwt = userService.loginByEmail(email);
         return new LoginResp(200, new LoginResponse(jwt));
     }
 

--- a/src/main/java/com/fthon/save_track/common/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/fthon/save_track/common/controller/GlobalControllerAdvice.java
@@ -1,0 +1,35 @@
+package com.fthon.save_track.common.controller;
+
+
+import com.fthon.save_track.common.dto.ErrorResponse;
+import com.fthon.save_track.common.exceptions.BadRequestException;
+
+import com.fthon.save_track.common.exceptions.UnAuthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+
+    @ExceptionHandler({BadRequestException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleBadRequestException(BadRequestException e){
+        return new ErrorResponse(400, e.getMessage(), ErrorResponse.ErrorInfo.of(e.getStackTrace()));
+    }
+
+    @ExceptionHandler({UnAuthorizedException.class})
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleUnAuthorizedException(UnAuthorizedException e){
+        return new ErrorResponse(401, e.getMessage(), ErrorResponse.ErrorInfo.of(e.getStackTrace()));
+    }
+
+    @ExceptionHandler({Exception.class})
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleUnexpectedException(Exception e){
+        return new ErrorResponse(500, e.getMessage(), ErrorResponse.ErrorInfo.of(e.getStackTrace()));
+    }
+
+}

--- a/src/main/java/com/fthon/save_track/common/dto/ErrorResponse.java
+++ b/src/main/java/com/fthon/save_track/common/dto/ErrorResponse.java
@@ -1,14 +1,13 @@
 package com.fthon.save_track.common.dto;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
+
+import java.util.Arrays;
 
 @AllArgsConstructor
 @Builder
-@Data
+@Getter
 public class ErrorResponse extends CommonResponse<ErrorResponse.ErrorInfo> {
 
     public ErrorResponse(int code, String message, ErrorInfo data) {
@@ -21,7 +20,13 @@ public class ErrorResponse extends CommonResponse<ErrorResponse.ErrorInfo> {
 
     @AllArgsConstructor
     @Getter
+    @NoArgsConstructor
     public static class ErrorInfo {
-        private final String[] stackTrace;
+        private String[] stackTrace;
+
+        public static ErrorInfo of(StackTraceElement[] stackTraceElements){
+
+            return new ErrorInfo(Arrays.stream(stackTraceElements).map(StackTraceElement::toString).toArray(String[]::new));
+        }
     }
 }

--- a/src/main/java/com/fthon/save_track/common/exceptions/BadRequestException.java
+++ b/src/main/java/com/fthon/save_track/common/exceptions/BadRequestException.java
@@ -1,0 +1,12 @@
+package com.fthon.save_track.common.exceptions;
+
+public class BadRequestException extends RuntimeException{
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/fthon/save_track/common/exceptions/UnAuthorizedException.java
+++ b/src/main/java/com/fthon/save_track/common/exceptions/UnAuthorizedException.java
@@ -1,0 +1,12 @@
+package com.fthon.save_track.common.exceptions;
+
+public class UnAuthorizedException extends RuntimeException{
+
+    public UnAuthorizedException(String message) {
+        super(message);
+    }
+
+    public UnAuthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/fthon/save_track/report/controller/ReportController.java
+++ b/src/main/java/com/fthon/save_track/report/controller/ReportController.java
@@ -5,13 +5,18 @@ import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
 import com.fthon.save_track.auth.resolvers.annotation.LoginedUser;
 import com.fthon.save_track.common.dto.CommonResponse;
 import com.fthon.save_track.common.dto.ErrorResponse;
+import com.fthon.save_track.common.exceptions.BadRequestException;
 import com.fthon.save_track.report.dto.ReportDateResponse;
+import com.fthon.save_track.report.service.ReportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,7 +31,10 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/reports")
 @Tag(name = "리포트 관련", description = "리포트 조회를 위한 API")
+@RequiredArgsConstructor
 public class ReportController {
+
+    private final ReportService reportService;
 
     @Operation(summary = "기간별 리포트 조회", description = "지정된 기간의 리포트를 조회합니다")
     @ApiResponse(responseCode = "200", description = "성공적으로 조회됨, swagger 응답양식의 additionalProps에는 yyyy-MM-dd 형식의 날짜가 들어갑니다.",
@@ -41,15 +49,25 @@ public class ReportController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
             @LoginedUser AuthenticatedUserDto userInfo
     ) {
-        return ResponseEntity.ok(null);
+        if(startDate.isAfter(endDate)){
+            throw new BadRequestException("조회 시작일은 종료일 보다 뒤일 수 없습니다.");
+        }
+
+
+        Map<LocalDate, List<ReportDateResponse>> result = reportService.getReportDateIn(userInfo.getId(), startDate, endDate);
+
+        return ResponseEntity.ok(new ReportListResponse(200, result));
     }
 
-    public static class ReportListResponse extends CommonResponse<Map<LocalDate, ReportDateResponse>> {
-        public ReportListResponse(int code, String message, Map<LocalDate, ReportDateResponse> data) {
+
+    @NoArgsConstructor
+    @Getter
+    public static class ReportListResponse extends CommonResponse<Map<LocalDate, List<ReportDateResponse>>> {
+        public ReportListResponse(int code, String message, Map<LocalDate, List<ReportDateResponse>> data) {
             super(code, message, data);
         }
 
-        public ReportListResponse(int code, Map<LocalDate, ReportDateResponse> data) {
+        public ReportListResponse(int code, Map<LocalDate, List<ReportDateResponse>> data) {
             super(code, data);
         }
     }

--- a/src/main/java/com/fthon/save_track/report/dto/ReportDateResponse.java
+++ b/src/main/java/com/fthon/save_track/report/dto/ReportDateResponse.java
@@ -6,15 +6,28 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class ReportDateResponse {
 
-    private String eventId;
+    private Long eventId;
     private String eventName;
-    private boolean isCheck;
+    private boolean checked;
     private ZonedDateTime checkTime;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReportDateResponse that = (ReportDateResponse) o;
+        return checked == that.checked && Objects.equals(eventId, that.eventId) && Objects.equals(eventName, that.eventName) && checkTime.isEqual(that.checkTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, eventName, checked, checkTime);
+    }
 }

--- a/src/main/java/com/fthon/save_track/report/service/ReportService.java
+++ b/src/main/java/com/fthon/save_track/report/service/ReportService.java
@@ -1,0 +1,58 @@
+package com.fthon.save_track.report.service;
+
+
+import com.fthon.save_track.report.dto.ReportDateResponse;
+import com.fthon.save_track.user.dto.UserEventLogDto;
+import com.fthon.save_track.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final UserService userService;
+
+    /**
+     * 사용자의 이벤트 클리어 여부를 날짜별로 조회하는 메서드
+     * @author minseok kim
+    */
+    public Map<LocalDate, List<ReportDateResponse>> getReportDateIn(Long userId, LocalDate startDate, LocalDate endDate) {
+        List<UserEventLogDto> eventLogs = userService.getEventLogDateIn(userId, startDate, endDate);
+
+        List<LocalDate> dates = generateDateRange(startDate, endDate);
+        Map<LocalDate, List<ReportDateResponse>> resultMap = new HashMap<>();
+
+        for(LocalDate date : dates){
+            resultMap.put(date, new ArrayList<>());
+        }
+
+        for(UserEventLogDto dto : eventLogs){
+            resultMap.get(dto.getCheckTime().toLocalDate()).add(
+                    new ReportDateResponse(
+                        dto.getEventId(),
+                        dto.getEventName(),
+                        dto.isCheck(),
+                        dto.getCheckTime()
+            ));
+        }
+
+        return resultMap;
+    }
+
+
+
+    private List<LocalDate> generateDateRange(LocalDate startDate, LocalDate endDate) {
+
+        return startDate.datesUntil(endDate.plusDays(1))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/fthon/save_track/user/dto/UserEventLogDto.java
+++ b/src/main/java/com/fthon/save_track/user/dto/UserEventLogDto.java
@@ -1,0 +1,42 @@
+package com.fthon.save_track.user.dto;
+
+
+import com.fthon.save_track.user.persistence.UserEventLog;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserEventLogDto {
+
+    private final Long eventId;
+    private final String eventName;
+    private boolean isCheck;
+    private ZonedDateTime checkTime;
+
+    public static UserEventLogDto of(UserEventLog log){
+        return new UserEventLogDto(
+                log.getEvent().getId(),
+                log.getEvent().getEventName(),
+                log.isChecked(),
+                log.getCreatedAt()
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserEventLogDto that = (UserEventLogDto) o;
+        return isCheck == that.isCheck && Objects.equals(eventId, that.eventId) && Objects.equals(eventName, that.eventName) && Objects.equals(checkTime, that.checkTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, eventName, isCheck, checkTime);
+    }
+}

--- a/src/main/java/com/fthon/save_track/user/service/UserService.java
+++ b/src/main/java/com/fthon/save_track/user/service/UserService.java
@@ -1,4 +1,4 @@
-package com.fthon.save_track.auth.service;
+package com.fthon.save_track.user.service;
 
 
 import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
@@ -6,19 +6,27 @@ import com.fthon.save_track.auth.dto.KakaoUserInfo;
 import com.fthon.save_track.auth.dto.OAuth2LoginRequest;
 import com.fthon.save_track.auth.service.client.KakaoOAuth2Client;
 import com.fthon.save_track.auth.utils.JwtUtils;
+import com.fthon.save_track.common.exceptions.UnAuthorizedException;
+import com.fthon.save_track.user.dto.UserEventLogDto;
 import com.fthon.save_track.user.persistence.User;
+import com.fthon.save_track.user.persistence.UserEventLog;
 import com.fthon.save_track.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class AuthService {
+public class UserService {
 
     private final KakaoOAuth2Client kakaoOAuth2Client;
     private final UserRepository userRepository;
@@ -48,6 +56,20 @@ public class AuthService {
         );
     }
 
+    public List<UserEventLogDto> getEventLogDateIn(Long userId, LocalDate startDate, LocalDate endDate){
+        User user = userRepository.findById(userId).orElseThrow(() -> new UnAuthorizedException("사용자 정보를 조회할 수 없습니다."));
+
+        return user.getLogs().stream().filter(log->
+                {
+                    ZonedDateTime startDateTime = ZonedDateTime.of(startDate, LocalTime.MIN, log.getCreatedAt().getZone());
+                    ZonedDateTime endDateTime = ZonedDateTime.of(endDate, LocalTime.MIN, log.getCreatedAt().getZone());
+                    return
+                            isEqualOrAfter(log.getCreatedAt(), startDateTime) &&
+                            isEqualOrBefore(log.getCreatedAt(), endDateTime);
+                }
+        ).map(UserEventLogDto::of).toList();
+    }
+
 
     @Transactional(readOnly = true)
     public String loginByEmail(String email){
@@ -71,4 +93,12 @@ public class AuthService {
         userRepository.save(user);
         return user;
     }
+
+    private boolean isEqualOrAfter(ZonedDateTime date1, ZonedDateTime date2) {
+        return date1.isEqual(date2) || date1.isAfter(date2);
+    }
+    private boolean isEqualOrBefore(ZonedDateTime date1, ZonedDateTime date2) {
+        return date1.isEqual(date2) || date1.isBefore(date2);
+    }
+
 }

--- a/src/main/java/com/fthon/save_track/user/service/UserService.java
+++ b/src/main/java/com/fthon/save_track/user/service/UserService.java
@@ -62,7 +62,7 @@ public class UserService {
         return user.getLogs().stream().filter(log->
                 {
                     ZonedDateTime startDateTime = ZonedDateTime.of(startDate, LocalTime.MIN, log.getCreatedAt().getZone());
-                    ZonedDateTime endDateTime = ZonedDateTime.of(endDate, LocalTime.MIN, log.getCreatedAt().getZone());
+                    ZonedDateTime endDateTime = ZonedDateTime.of(endDate, LocalTime.MAX, log.getCreatedAt().getZone());
                     return
                             isEqualOrAfter(log.getCreatedAt(), startDateTime) &&
                             isEqualOrBefore(log.getCreatedAt(), endDateTime);
@@ -76,7 +76,7 @@ public class UserService {
         Optional<User> user = userRepository.findByEmail(email);
 
         if(user.isEmpty()){
-            throw new RuntimeException("유저를 조회할 수 없습니다.");
+            throw new UnAuthorizedException("유저를 조회할 수 없습니다.");
         }
 
         return jwtUtils.sign(AuthenticatedUserDto.of(user.get()), new Date());

--- a/src/test/java/com/fthon/save_track/report/integration/ReportIntegrationTest.java
+++ b/src/test/java/com/fthon/save_track/report/integration/ReportIntegrationTest.java
@@ -1,0 +1,162 @@
+package com.fthon.save_track.report.integration;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fthon.save_track.auth.dto.AuthenticatedUserDto;
+import com.fthon.save_track.auth.utils.JwtUtils;
+import com.fthon.save_track.common.dto.ErrorResponse;
+import com.fthon.save_track.event.persistence.Category;
+import com.fthon.save_track.event.persistence.CategoryRepository;
+import com.fthon.save_track.event.persistence.Event;
+import com.fthon.save_track.event.persistence.EventRepository;
+import com.fthon.save_track.report.controller.ReportController;
+import com.fthon.save_track.report.dto.ReportDateResponse;
+import com.fthon.save_track.user.persistence.User;
+import com.fthon.save_track.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.assertj.core.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class ReportIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtUtils jwtUtils;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("사용자의 기간별 이벤트 성공 여부를 조회할 수 있다.")
+    public void testGetReport() throws Exception{
+        //given
+        User user = new User();
+        Category category = new Category();
+
+        Event event1 = new Event(category, List.of(), "이벤트", "내용", "메시지1", "메시지2", "메시지3");
+        Event event2 = new Event(category, List.of(), "이벤트2", "내용", "메시지1", "메시지2", "메시지3");
+
+        user.addLog(event1, true);
+        user.addLog(event2, false);
+
+
+        categoryRepository.save(category);
+        eventRepository.saveAll(List.of(event1, event2));
+        userRepository.save(user);
+
+        //when
+        String uri = "/api/reports";
+        String jwt = jwtUtils.sign(AuthenticatedUserDto.of(user), new Date());
+
+        LocalDate startDate = LocalDate.now().minusDays(3);
+        LocalDate endDate = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        MvcResult mvcResult = mockMvc.perform(get(uri)
+                .param("startDate", startDate.format(formatter))
+                .param("endDate", endDate.format(formatter))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
+        ).andDo(
+                print()
+        ).andReturn();
+
+        //then
+        ReportController.ReportListResponse actual = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ReportController.ReportListResponse.class);
+
+        List<ReportDateResponse> expectedEndDateData = user.getLogs().stream().map(log->{
+            return new ReportDateResponse(log.getEvent().getId(), log.getEvent().getEventName(), log.isChecked(), log.getCreatedAt());
+        }).toList();
+
+
+        assertThat(actual.getCode()).isEqualTo(200);
+
+        // startDate ~ endDate까지의 데이터가 모두 들어가있어야 한다.
+        assertThat(actual.getData().keySet()).containsAll(
+                List.of(
+                    startDate,
+                    startDate.plusDays(1),
+                    startDate.plusDays(2),
+                    endDate
+                )
+        );
+
+
+        // 마지막 날에만 데이터가 들어있어야 한다.
+        for(int i = 0; i < 3; i++){
+            List<ReportDateResponse> expectedEmpty = actual.getData().get(startDate.plusDays(i));
+            assertThat(expectedEmpty).isEmpty();
+        }
+        List<ReportDateResponse> actualEndDateData = actual.getData().get(endDate);
+
+        assertThat(actualEndDateData).containsAll(expectedEndDateData);
+
+
+
+    }
+
+    @Test
+    @DisplayName("StartDate가 EndDate보다 후면 400 오류를 반환한다.")
+    public void testStartDateIsAfterEndDate() throws Exception{
+        //given
+        User user = new User();
+
+        //when
+        String uri = "/api/reports";
+        String jwt = jwtUtils.sign(AuthenticatedUserDto.of(user), new Date());
+
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = LocalDate.now().minusDays(3);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        MvcResult mvcResult = mockMvc.perform(get(uri)
+                .param("startDate", startDate.format(formatter))
+                .param("endDate", endDate.format(formatter))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwt)
+        ).andDo(
+                print()
+        ).andReturn();
+
+        //then
+        ErrorResponse errorResponse = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ErrorResponse.class);
+
+        assertThat(mvcResult.getResponse().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(errorResponse.getCode()).isEqualTo(400);
+
+    }
+
+
+
+}


### PR DESCRIPTION
### 개요
- 기간별 리포트를 조회하는 API와 공통 ExceptionHandler를 정의하였습니다.

### 상세
- 기간별 리포트를 조회하는 API 예시는 다음과 같습니다.

```
/api/reports?startDate=2024-09-08&endDate=2024-09-11
```
- API 응답 예시는 다음과 같습니다.
```
{
    "code": 200,
    "message": null,
    "data": {
        "2024-09-11": [
            {
                "eventId": 621715020658841876,
                "eventName": "이벤트",
                "checked": true,
                "checkTime": "2024-09-11T23:33:31.8329126+09:00"
            },
            {
                "eventId": 621715020663034456,
                "eventName": "이벤트2",
                "checked": false,
                "checkTime": "2024-09-11T23:33:31.8329126+09:00"
            }
        ],
        "2024-09-10": [],
        "2024-09-09": [],
        "2024-09-08": []
    }
}
```
- 위 예시에서도 볼 수 있듯, 완료한 이벤트가 없더라도 data에 날짜 정보는 포함되어 있습니다.